### PR TITLE
Adding a helpful comment for the button TODO

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -53,7 +53,8 @@
     <!-- TODO 3: Define a button for the login screen -->
     <!-- - Set the layout_width and layout_height to "wrap_content"
          - Set the text to "Login"
-         - Set the id to "login_btn" -->
+         - Set the id to "login_btn"
+         - Remove the weight attribute if you use the design tab -->
 
 
 


### PR DESCRIPTION
If you use the design tab to create the button in TODO #3, it automatically assigns a weight to the button that makes it look a lot bigger than intended. If they remove this weight or don't set it at all, it'll look as expected. 